### PR TITLE
feat: action-required pill for stale unmerged local branches

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -9,14 +9,14 @@ This doc describes capabilities. The egress surfaces (HTTP JSON + MCP) are summa
 Joins three primary sources into one queryable surface, all on the same host:
 
 - **Claude Code sessions** parsed from `~/.claude/projects/**/*.jsonl`. Metadata, 200-char summaries, malformed lines skipped.
-- **git** via `git log --all --no-merges` and working-tree status. Untracked + modified counts, stash, branch, ahead/behind, in-progress op, detached HEAD.
+- **git** via `git log --all --no-merges` and working-tree status. Untracked + modified counts, stash, branch, ahead/behind, in-progress op, detached HEAD, stale unmerged local branches.
 - **GitHub** via `gh` REST: CI status, open and draft PRs, issues, review queue, deploy workflow status. No GraphQL.
 
 Joins by `cwd` (longest-prefix) plus a fuzzy content-mention pass. `session_repos.match_type` is the extension point.
 
 ## Action-required surfacing
 
-Curated set of signals that float to the top of any ranking: failing CI, dirty tree, in-progress git op, detached HEAD, review-requested PRs, drafts and no-reviewer, assigned issues, deploy failing or stale. Each item is stable across scans by `(repo_id, signal)` so a polling consumer can dedupe.
+Curated set of signals that float to the top of any ranking: failing CI, dirty tree, in-progress git op, detached HEAD, review-requested PRs, drafts and no-reviewer, assigned issues, deploy failing or stale, stale unmerged local branches (a branch with commits older than 24h not merged into the default branch). Each item is stable across scans by `(repo_id, signal)` so a polling consumer can dedupe.
 
 ## Activity ranking
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -188,6 +188,17 @@ pub struct SearchHit {
     pub extra: Option<String>,
 }
 
+/// One local branch carrying unmerged commits older than the staleness
+/// threshold - unlanded work left sitting. Stored on the `Repo` record and
+/// surfaced as an action-required pill. See #228.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StaleBranch {
+    /// Short branch name, e.g. `feature/foo`.
+    pub name: String,
+    /// Unix timestamp of the branch tip (its newest commit).
+    pub tip_ts: i64,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Repo {
     pub id: i64,
@@ -218,6 +229,11 @@ pub struct Repo {
     pub deploy_last_success_ts: Option<i64>,
     pub remote_url: Option<String>,
     pub default_branch: Option<String>,
+    /// Local branches with unmerged commits older than 24h - see #228.
+    /// `#[serde(default)]` keeps the record forward-compatible: a cache
+    /// written before this field existed still deserialises.
+    #[serde(default)]
+    pub stale_branches: Vec<StaleBranch>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -1814,6 +1830,7 @@ impl CacheWriter<'_> {
             deploy_last_success_ts: None,
             remote_url: remote_url.map(str::to_string),
             default_branch: default_branch.map(str::to_string),
+            stale_branches: Vec::new(),
         };
         let _ = discovered_at; // discovery time is not surfaced anywhere
         let bytes = serde_json::to_vec(&repo)?;
@@ -2257,6 +2274,7 @@ impl CacheWriter<'_> {
         stash_count: i64,
         head_ref: Option<&str>,
         in_progress_op: Option<&str>,
+        stale_branches: Vec<StaleBranch>,
     ) -> Result<()> {
         self.mutate_repo(repo_id, |r| {
             r.loc_churn_30d = loc_churn_30d;
@@ -2267,6 +2285,7 @@ impl CacheWriter<'_> {
             r.stash_count = stash_count;
             r.head_ref = head_ref.map(str::to_string);
             r.in_progress_op = in_progress_op.map(str::to_string);
+            r.stale_branches = stale_branches.clone();
         })
     }
 

--- a/src/display/routes/dashboard.rs
+++ b/src/display/routes/dashboard.rs
@@ -62,6 +62,7 @@ pub struct BannerCounts {
     pub issue_assigned: i64,
     pub deploy_failing: usize,
     pub deploy_stale: usize,
+    pub stale_branches: usize,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -164,6 +165,10 @@ pub async fn index(
         .iter()
         .filter(|r| activity::is_deploy_stale(r))
         .count();
+    let stale_branches_count = repos
+        .iter()
+        .filter(|r| !activity::is_vendored(r) && activity::has_stale_branches(r))
+        .count();
 
     let norms = activity::normalisers(&repos);
     let repo_json: Vec<RepoJson> = repos
@@ -211,6 +216,7 @@ pub async fn index(
             issue_assigned: issue_assigned_count,
             deploy_failing: deploy_failing_count,
             deploy_stale: deploy_stale_count,
+            stale_branches: stale_branches_count,
         },
         counts: DashboardCounts {
             repos: repos_n,

--- a/src/display/routes/refresh.rs
+++ b/src/display/routes/refresh.rs
@@ -769,6 +769,11 @@ fn ingest_commits(
             // DB.
             let snap = git::log::worktree_snapshot(repo_path, 50);
             let local = git::log::local_state(repo_path);
+            // Local branches carrying unmerged commits older than 24h -
+            // unlanded work to land or clean up. See #228.
+            let stale_cutoff =
+                chrono::Utc::now().timestamp() - crate::process::activity::STALE_BRANCH_SECS;
+            let stale_branches = git::log::stale_branches(repo_path, stale_cutoff);
             w.update_repo_local_state(
                 *repo_id,
                 churn,
@@ -779,6 +784,7 @@ fn ingest_commits(
                 local.stash_count,
                 local.head_ref.as_deref(),
                 local.in_progress_op.as_deref(),
+                stale_branches,
             )?;
             for f in &snap.files {
                 w.insert_uncommitted_file(*repo_id, &f.path, f.kind.as_str())?;

--- a/src/ingest/git/log.rs
+++ b/src/ingest/git/log.rs
@@ -417,6 +417,107 @@ pub fn local_state(repo_path: &Path) -> LocalState {
     }
 }
 
+/// Local branches that carry unmerged commits older than `cutoff_ts`.
+///
+/// A branch is "stale and unmerged" when its tip commit is older than the
+/// cutoff *and* the branch is not fully merged into the repo's default
+/// branch. Branches already merged (but not yet deleted) are deliberately
+/// excluded - the signal we want is unlanded work left sitting, not stale
+/// cleanup of already-landed branches. See #228.
+///
+/// `cutoff_ts` is a Unix timestamp: a branch whose tip is at or before it
+/// counts as stale. Result is sorted oldest-tip-first so the worst
+/// offender leads any rendered list.
+///
+/// Returns empty when the default branch can't be resolved (a bare clone
+/// with no `origin/HEAD` and no local `main`/`master`) - without a merge
+/// target there's no way to tell unlanded work from landed.
+pub fn stale_branches(repo_path: &Path, cutoff_ts: i64) -> Vec<crate::db::StaleBranch> {
+    let Some(path_str) = repo_path.to_str() else {
+        return Vec::new();
+    };
+    let git = |args: &[&str]| -> Option<String> {
+        let mut full = vec!["-C", path_str];
+        full.extend_from_slice(args);
+        let out = Command::new("git").args(full).output().ok()?;
+        if !out.status.success() {
+            return None;
+        }
+        Some(String::from_utf8_lossy(&out.stdout).trim().to_string())
+    };
+
+    // Resolve the default branch as both a short name (to exclude it from
+    // the candidate list) and a revision usable as a merge-base target.
+    // Prefer `origin/HEAD` - the remote's notion of the trunk - and fall
+    // back to a local `main` / `master`.
+    let (default_short, default_rev): (String, String) =
+        git(&["symbolic-ref", "refs/remotes/origin/HEAD"])
+            .and_then(|s| {
+                s.strip_prefix("refs/remotes/origin/")
+                    .map(|short| (short.to_string(), "refs/remotes/origin/HEAD".to_string()))
+            })
+            .or_else(|| {
+                ["main", "master"].into_iter().find_map(|name| {
+                    let r = format!("refs/heads/{name}");
+                    git(&["rev-parse", "--verify", "--quiet", &r]).map(|_| (name.to_string(), r))
+                })
+            })
+            .unwrap_or_default();
+    if default_short.is_empty() {
+        return Vec::new();
+    }
+
+    // One `for-each-ref` lists every local branch with its tip's committer
+    // date as a Unix timestamp - no per-branch subprocess for the age check.
+    let Some(listing) = git(&[
+        "for-each-ref",
+        "--format=%(refname:short)%09%(committerdate:unix)",
+        "refs/heads/",
+    ]) else {
+        return Vec::new();
+    };
+
+    let mut stale: Vec<crate::db::StaleBranch> = Vec::new();
+    for line in listing.lines() {
+        let mut parts = line.split('\t');
+        let Some(name) = parts.next() else { continue };
+        let Some(tip_ts) = parts.next().and_then(|s| s.parse::<i64>().ok()) else {
+            continue;
+        };
+        if name.is_empty() || name == default_short {
+            continue;
+        }
+        // Recent work - the branch is still warm, not "left sitting".
+        if tip_ts > cutoff_ts {
+            continue;
+        }
+        // Fully merged into the default branch: landed work, not action-
+        // required. `--is-ancestor` exits 0 when the branch tip is an
+        // ancestor of the default branch.
+        let merged = Command::new("git")
+            .args([
+                "-C",
+                path_str,
+                "merge-base",
+                "--is-ancestor",
+                &format!("refs/heads/{name}"),
+                &default_rev,
+            ])
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if merged {
+            continue;
+        }
+        stale.push(crate::db::StaleBranch {
+            name: name.to_string(),
+            tip_ts,
+        });
+    }
+    stale.sort_by_key(|b| b.tip_ts);
+    stale
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FileKind {
     Untracked,
@@ -822,7 +923,100 @@ fn parse_owner_repo(raw: &str) -> Option<OwnerRepo> {
 
 #[cfg(test)]
 mod tests {
-    use super::{normalize_remote_url, parse_numstat_path};
+    use super::{normalize_remote_url, parse_numstat_path, stale_branches};
+    use std::process::Command;
+
+    /// Spin up a throwaway git repo for the `stale_branches` tests, run a
+    /// closure against its path, then clean up.
+    fn with_temp_repo(f: impl FnOnce(&std::path::Path)) {
+        let dir = std::env::temp_dir().join(format!(
+            "repo-recall-stale-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        f(&dir);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Run a git command in `dir`, optionally pinning author + committer
+    /// dates so a commit can be backdated. Panics on failure - test setup
+    /// has no recovery path.
+    fn git(dir: &std::path::Path, date: Option<&str>, args: &[&str]) {
+        let mut cmd = Command::new("git");
+        cmd.arg("-C").arg(dir).args(args);
+        if let Some(d) = date {
+            cmd.env("GIT_AUTHOR_DATE", d).env("GIT_COMMITTER_DATE", d);
+        }
+        let out = cmd.output().expect("git command runs");
+        assert!(
+            out.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+
+    /// Stage every change and commit it, backdated to `date`.
+    fn commit(dir: &std::path::Path, date: &str, message: &str) {
+        git(dir, None, &["add", "-A"]);
+        git(dir, Some(date), &["commit", "-m", message]);
+    }
+
+    #[test]
+    fn stale_branches_flags_only_unmerged_old_work() {
+        with_temp_repo(|dir| {
+            let now = chrono::Utc::now().timestamp();
+            let old = format!("@{} +0000", now - 5 * 86_400);
+            let recent = format!("@{now} +0000");
+
+            git(dir, None, &["-c", "init.defaultBranch=main", "init"]);
+            git(dir, None, &["config", "user.email", "t@example.com"]);
+            git(dir, None, &["config", "user.name", "Tester"]);
+
+            // main: a recent base commit.
+            std::fs::write(dir.join("README"), "base").unwrap();
+            commit(dir, &recent, "base");
+
+            // stale-unmerged: an old commit never merged back to main.
+            git(dir, None, &["checkout", "-b", "stale-unmerged"]);
+            std::fs::write(dir.join("a.txt"), "old work").unwrap();
+            commit(dir, &old, "old unmerged work");
+
+            // merged-old: an old commit, but landed into main - not action-
+            // required even though the branch ref still exists.
+            git(dir, None, &["checkout", "main"]);
+            git(dir, None, &["checkout", "-b", "merged-old"]);
+            std::fs::write(dir.join("b.txt"), "landed work").unwrap();
+            commit(dir, &old, "old landed work");
+            git(dir, None, &["checkout", "main"]);
+            git(dir, None, &["merge", "--no-ff", "--no-edit", "merged-old"]);
+
+            // recent-work: an unmerged commit, but too fresh to be stale.
+            git(dir, None, &["checkout", "-b", "recent-work"]);
+            std::fs::write(dir.join("c.txt"), "fresh work").unwrap();
+            commit(dir, &recent, "fresh unmerged work");
+            git(dir, None, &["checkout", "main"]);
+
+            let cutoff = now - 24 * 3_600;
+            let stale = stale_branches(dir, cutoff);
+            let names: Vec<&str> = stale.iter().map(|b| b.name.as_str()).collect();
+            assert_eq!(names, vec!["stale-unmerged"], "got {stale:?}");
+            assert!(stale[0].tip_ts <= cutoff);
+        });
+    }
+
+    #[test]
+    fn stale_branches_empty_without_default_branch() {
+        with_temp_repo(|dir| {
+            // A repo with no commits and no resolvable trunk: nothing to
+            // measure unmerged work against, so the result is empty.
+            git(dir, None, &["-c", "init.defaultBranch=trunk", "init"]);
+            assert!(stale_branches(dir, chrono::Utc::now().timestamp()).is_empty());
+        });
+    }
 
     #[test]
     fn parse_numstat_path_no_rename() {

--- a/src/process/activity.rs
+++ b/src/process/activity.rs
@@ -216,6 +216,12 @@ pub fn score(repo: &Repo, norms: &[f64]) -> f64 {
 /// older than this, the deploy path itself probably rotted.
 pub const DEPLOY_STALE_SECS: i64 = 7 * 86_400;
 
+/// Threshold for the stale-local-branch signal: a local branch whose tip
+/// commit is older than this, and which isn't merged into the default
+/// branch, is treated as unlanded work that needs landing or cleanup.
+/// Named constant rather than a literal so it stays tunable. See #228.
+pub const STALE_BRANCH_SECS: i64 = 24 * 3_600;
+
 /// Current triggers:
 /// - Failing default-branch CI
 /// - Dirty working tree (untracked + modified)
@@ -228,6 +234,7 @@ pub const DEPLOY_STALE_SECS: i64 = 7 * 86_400;
 /// - Issue assigned to me
 /// - Deploy workflow's last run failed
 /// - Deploy workflow has been silent for > 7d since its last green run
+/// - A local branch carries unmerged commits older than 24h
 pub fn is_action_required(r: &Repo) -> bool {
     if is_vendored(r) {
         return false;
@@ -243,6 +250,15 @@ pub fn is_action_required(r: &Repo) -> bool {
         || r.issues_assigned_to_me > 0
         || is_deploy_failing(r)
         || is_deploy_stale(r)
+        || has_stale_branches(r)
+}
+
+/// True when the repo has at least one stale, unmerged local branch. The
+/// detection (age + merged filter) happens at refresh time in
+/// [`crate::ingest::git::log::stale_branches`]; this just reads the result
+/// off the `Repo` record.
+pub fn has_stale_branches(r: &Repo) -> bool {
+    !r.stale_branches.is_empty()
 }
 
 /// Vendored / external repo: a third-party tree cloned for reading, not for
@@ -339,6 +355,7 @@ mod tests {
             deploy_last_success_ts: None,
             remote_url: None,
             default_branch: None,
+            stale_branches: Vec::new(),
         }
     }
 
@@ -429,6 +446,22 @@ mod tests {
         assert!(!is_action_required(&detached));
 
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn stale_branches_trigger_action_required() {
+        let mut clean = repo(1, "clean", 0, 0);
+        clean.head_ref = Some("main".into());
+        assert!(!is_action_required(&clean));
+
+        let mut has_stale = repo(2, "has-stale", 0, 0);
+        has_stale.head_ref = Some("main".into());
+        has_stale.stale_branches = vec![crate::db::StaleBranch {
+            name: "feature/old".into(),
+            tip_ts: 1_700_000_000,
+        }];
+        assert!(has_stale_branches(&has_stale));
+        assert!(is_action_required(&has_stale));
     }
 
     #[test]

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -117,6 +117,28 @@ pub fn derive_action_signals(r: &db::Repo) -> Vec<DerivedSignal> {
             detail: format!("`{wf}` last green {days}d ago"),
         });
     }
+    if !r.stale_branches.is_empty() {
+        let n = r.stale_branches.len();
+        let now = chrono::Utc::now().timestamp();
+        let named: Vec<String> = r
+            .stale_branches
+            .iter()
+            .take(5)
+            .map(|b| {
+                let age_days = ((now - b.tip_ts) / 86_400).max(0);
+                format!("{} ({age_days}d)", b.name)
+            })
+            .collect();
+        let suffix = if n > named.len() { ", ..." } else { "" };
+        out.push(DerivedSignal {
+            signal: "stale_branches",
+            detail: format!(
+                "{n} local branch{} with unmerged commits >24h old: {}{suffix}",
+                if n == 1 { "" } else { "es" },
+                named.join(", "),
+            ),
+        });
+    }
     let _ = activity::is_action_required;
     out
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,3 +1,8 @@
+export type StaleBranch = {
+  name: string;
+  tip_ts: number;
+};
+
 export type Repo = {
   id: number;
   path: string;
@@ -27,6 +32,7 @@ export type Repo = {
   deploy_last_success_ts: number | null;
   remote_url: string | null;
   default_branch: string | null;
+  stale_branches: StaleBranch[];
   action_required: boolean;
   action_signals: string[];
   activity_score: number;


### PR DESCRIPTION
## What

repo-recall now flags any local branch whose tip commit is older than 24h and which is **not** merged into the default branch. The assumption from #228: that's unlanded work left sitting, either land it or delete the branch.

closes #228

## How

- **Detection** - `git::log::stale_branches(repo_path, cutoff_ts)`. One `for-each-ref` pulls every local branch with its tip's committer date. A `merge-base --is-ancestor` per candidate drops branches already landed into the default branch (the load-bearing filter from the issue). Default branch resolves from `origin/HEAD`, falling back to a local `main` / `master`; with no resolvable trunk there's no merge target, so the result is empty.
- **Storage** - results land on the `Repo` record as `stale_branches: Vec<StaleBranch>` (`#[serde(default)]`, forward-compatible). Written in the existing local-state refresh pass.
- **Surface** - feeds `activity::is_action_required` plus a new `stale_branches` derived signal in `signals.rs`, so the dashboard action-required pill and the MCP `recall_action_required` surface both light up with no new component shape. The pill detail names the offending branches with ages. A `stale_branches` banner counter mirrors the other action signals.
- **Threshold** - the 24h cut is the named `activity::STALE_BRANCH_SECS` constant, alongside the existing `DEPLOY_STALE_SECS`, so it stays tunable.

## Tests

- `git::log::stale_branches` fixture test: a real temp git repo with a stale-unmerged branch, an old-but-merged branch, and a fresh unmerged branch - asserts only the stale-unmerged one is flagged.
- Empty result when the default branch can't be resolved.
- `activity::is_action_required` lights up on a non-empty `stale_branches`.
- Full `make ci` green; web SPA build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
