### PR TITLE
feat(activity): add push action-required signal for unpushed commits

### DIFF
--- a/src/display/routes/dashboard.rs
+++ b/src/display/routes/dashboard.rs
@@ -60,6 +60,7 @@ pub struct BannerCounts {
     pub detached_heads: usize,
     pub review_requested: i64,
     pub issue_assigned: i64,
+    pub push: usize,
     pub deploy_failing: usize,
     pub deploy_stale: usize,
 }
@@ -154,6 +155,10 @@ pub async fn index(
         .iter()
         .filter(|r| !activity::is_vendored(r) && r.head_ref.as_deref() == Some("detached"))
         .count();
+    let push_count = repos
+        .iter()
+        .filter(|r| !activity::is_vendored(r) && r.commits_ahead > 0)
+        .count();
     let review_requested_count: i64 = repos.iter().map(|r| r.prs_awaiting_my_review).sum();
     let issue_assigned_count: i64 = repos.iter().map(|r| r.issues_assigned_to_me).sum();
     let deploy_failing_count = repos
@@ -209,6 +214,7 @@ pub async fn index(
             detached_heads: detached_count,
             review_requested: review_requested_count,
             issue_assigned: issue_assigned_count,
+            push: push_count,
             deploy_failing: deploy_failing_count,
             deploy_stale: deploy_stale_count,
         },

--- a/src/process/activity.rs
+++ b/src/process/activity.rs
@@ -226,8 +226,12 @@ pub const DEPLOY_STALE_SECS: i64 = 7 * 86_400;
 /// - My open PR with no reviewer requested (you are the blocker)
 /// - My non-draft PR open (test it, ask for review)
 /// - Issue assigned to me
+/// - Current branch has local commits not pushed to its upstream (`push`)
 /// - Deploy workflow's last run failed
 /// - Deploy workflow has been silent for > 7d since its last green run
+///
+/// `commits_behind` stays informational - it's drift that self-resolves on
+/// the next pull, not a todo (see #233/#234).
 pub fn is_action_required(r: &Repo) -> bool {
     if is_vendored(r) {
         return false;
@@ -241,6 +245,7 @@ pub fn is_action_required(r: &Repo) -> bool {
         || r.prs_mine_awaiting_review > 0
         || r.prs_mine_no_reviewer > 0
         || r.issues_assigned_to_me > 0
+        || r.commits_ahead > 0
         || is_deploy_failing(r)
         || is_deploy_stale(r)
 }
@@ -406,6 +411,24 @@ mod tests {
         let mut on_main = repo(3, "on-main", 0, 0);
         on_main.head_ref = Some("main".into());
         assert!(!is_action_required(&on_main));
+    }
+
+    #[test]
+    fn unpushed_commits_trigger_action_required() {
+        let mut clean = repo(1, "clean", 0, 0);
+        clean.head_ref = Some("main".into());
+        assert!(!is_action_required(&clean));
+
+        let mut ahead = repo(2, "ahead", 0, 0);
+        ahead.head_ref = Some("main".into());
+        ahead.commits_ahead = 3;
+        assert!(is_action_required(&ahead));
+
+        // `commits_behind` stays informational - not a todo.
+        let mut behind = repo(3, "behind", 0, 0);
+        behind.head_ref = Some("main".into());
+        behind.commits_behind = 4;
+        assert!(!is_action_required(&behind));
     }
 
     #[test]

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -10,7 +10,12 @@ use crate::process::activity;
 
 pub struct DerivedSignal {
     pub signal: &'static str,
+    /// Chatty, JSON-facing description. Carries counts, op names, branch
+    /// text - whatever a machine consumer wants spelled out.
     pub detail: String,
+    /// Pre-capped one-liner for the human `watch curl` render. Never wraps,
+    /// flat, greppable. Rendered as `<repo>: <terse>` (see #233).
+    pub terse: String,
 }
 
 /// Map a `Repo` row's individual fields onto the curated set of signals
@@ -23,9 +28,11 @@ pub fn derive_action_signals(r: &db::Repo) -> Vec<DerivedSignal> {
         return out;
     }
     if r.ci_status.as_deref() == Some("failure") {
+        let branch = r.default_branch.as_deref().unwrap_or("default branch");
         out.push(DerivedSignal {
             signal: "ci_failing",
             detail: "default-branch CI failed".into(),
+            terse: format!("CI failing on {branch}"),
         });
     }
     let dirty = r.untracked_files + r.modified_files;
@@ -38,18 +45,24 @@ pub fn derive_action_signals(r: &db::Repo) -> Vec<DerivedSignal> {
                 r.modified_files,
                 r.untracked_files,
             ),
+            terse: format!(
+                "{dirty} uncommitted file{}",
+                if dirty == 1 { "" } else { "s" }
+            ),
         });
     }
     if let Some(op) = r.in_progress_op.as_deref() {
         out.push(DerivedSignal {
             signal: "in_progress_op",
             detail: format!("{op} in progress"),
+            terse: format!("{op} in progress"),
         });
     }
     if r.head_ref.as_deref() == Some("detached") {
         out.push(DerivedSignal {
             signal: "detached_head",
             detail: "HEAD is detached".into(),
+            terse: "detached HEAD".into(),
         });
     }
     if r.prs_awaiting_my_review > 0 {
@@ -59,6 +72,10 @@ pub fn derive_action_signals(r: &db::Repo) -> Vec<DerivedSignal> {
             detail: format!(
                 "{n} PR{} awaiting your review",
                 if n == 1 { "" } else { "s" },
+            ),
+            terse: format!(
+                "{n} PR{} awaiting your review",
+                if n == 1 { "" } else { "s" }
             ),
         });
     }
@@ -70,6 +87,7 @@ pub fn derive_action_signals(r: &db::Repo) -> Vec<DerivedSignal> {
                 "{n} draft PR{} of yours - get into a reviewable state",
                 if n == 1 { "" } else { "s" },
             ),
+            terse: format!("{n} draft PR{} to finish", if n == 1 { "" } else { "s" }),
         });
     }
     if r.prs_mine_no_reviewer > 0 {
@@ -81,6 +99,7 @@ pub fn derive_action_signals(r: &db::Repo) -> Vec<DerivedSignal> {
                 if n == 1 { "" } else { "s" },
                 if n == 1 { "has" } else { "have" },
             ),
+            terse: format!("{n} PR{} need a reviewer", if n == 1 { "" } else { "s" }),
         });
     }
     if r.prs_mine_awaiting_review > 0 {
@@ -91,6 +110,7 @@ pub fn derive_action_signals(r: &db::Repo) -> Vec<DerivedSignal> {
                 "{n} open PR{} of yours - test it before they review",
                 if n == 1 { "" } else { "s" },
             ),
+            terse: format!("{n} open PR{} to test", if n == 1 { "" } else { "s" }),
         });
     }
     if r.issues_assigned_to_me > 0 {
@@ -98,6 +118,18 @@ pub fn derive_action_signals(r: &db::Repo) -> Vec<DerivedSignal> {
         out.push(DerivedSignal {
             signal: "issue_assigned",
             detail: format!("{n} issue{} assigned to you", if n == 1 { "" } else { "s" },),
+            terse: format!("{n} issue{} assigned to you", if n == 1 { "" } else { "s" }),
+        });
+    }
+    if r.commits_ahead > 0 {
+        let n = r.commits_ahead;
+        out.push(DerivedSignal {
+            signal: "push",
+            detail: format!(
+                "{n} local commit{} not pushed to the upstream branch",
+                if n == 1 { "" } else { "s" },
+            ),
+            terse: format!("push {n} commit{}", if n == 1 { "" } else { "s" }),
         });
     }
     if activity::is_deploy_failing(r) {
@@ -105,6 +137,7 @@ pub fn derive_action_signals(r: &db::Repo) -> Vec<DerivedSignal> {
         out.push(DerivedSignal {
             signal: "deploy_failing",
             detail: format!("last `{wf}` run on the default branch failed"),
+            terse: "deploy failing".into(),
         });
     } else if activity::is_deploy_stale(r) {
         let wf = r.deploy_workflow.as_deref().unwrap_or("deploy");
@@ -115,6 +148,7 @@ pub fn derive_action_signals(r: &db::Repo) -> Vec<DerivedSignal> {
         out.push(DerivedSignal {
             signal: "deploy_stale",
             detail: format!("`{wf}` last green {days}d ago"),
+            terse: format!("deploy stale ({days}d)"),
         });
     }
     let _ = activity::is_action_required;


### PR DESCRIPTION
Closes #234. Part of #233.

Flips `commits_ahead` from informational to action-required, adds a `push` `DerivedSignal` (HTTP + MCP), a `push` banner counter, and the `terse` field from #233's tracer-bullet design (populated for every signal with the #233 vocabulary).

`commits_behind` stays informational - it self-resolves on the next pull.

`coily exec ci` green: fmt + clippy + check + 13 smoke tests + unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)